### PR TITLE
Add function to get slice of tree consiting of one version only.

### DIFF
--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -508,29 +508,7 @@ func (tree *MutableTree) addOrphans(orphans []*Node) {
 // SaveVersionToDB creates a copy of the current tree consisting of the given version.
 // and saves only the data for that version to the given database.
 // Use version == 0 to save the latest version.
-func (tree *MutableTree) SaveVersionToDB(version int64, newDb dbm.DB, savesPerCommit uint64) ([]byte, int64, error) {
-	if version == 0 {
-		version = tree.ndb.getLatestVersion()
-	}
-
-	// Build a new tree from our desired version
-	immutableTree, err := tree.GetImmutable(version)
-	if err != nil {
-		return nil, 0, cmn.NewError("Getting imutable tree: %v", err)
-	}
-
-	newNdb := newNodeDB(newDb, tree.ndb.nodeCacheSize)
-	newNdb.latestVersion = version - 1
-	if err := newNdb.SaveRoot(tree.root, version); err != nil {
-		return nil, 0, err
-	}
-	savesSinceLastCommit := uint64(0)
-	tree.root.LoadAndSave(immutableTree, newNdb, savesPerCommit, &savesSinceLastCommit)
-	newNdb.Commit()
-	return tree.root.hash, version, nil
-}
-
-func (tree *MutableTree) SaveVersionToDBDebug(
+func (tree *MutableTree) SaveVersionToDB(
 	version int64,
 	newDb dbm.DB,
 	savesPerCommit uint64,

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -552,6 +552,7 @@ func (tree *MutableTree) SaveVersionToDBDebug(
 		return nil, 0, err
 	}
 	savesSinceLastCommit := uint64(0)
-	tree.root.LoadAndSaveCallback(immutableTree, *newNdb, savesPerCommit, &savesSinceLastCommit, callback)
+	tree.root.LoadAndSaveCallback(immutableTree, newNdb, savesPerCommit, &savesSinceLastCommit, callback)
+	newNdb.Commit()
 	return tree.root.hash, version, nil
 }

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -505,9 +505,13 @@ func (tree *MutableTree) addOrphans(orphans []*Node) {
 // IMPORTANT This function assumes there has been no transactions since the last SaveVersion. If unsure about
 // this do a SaveVersion immediately before calling this function.
 //
-// SaveVersionToDB creates a copy of the current tree consisting of the given version.
-// and saves only the data for that version to the given database.
-// Use version == 0 to save the latest version.
+// SaveVersionToDB creates a copy of the current tree consisting of just one version
+// version - The version we wish to clone. Use version == 0 to save the latest version.
+// newDb   - Database to hold the cloned data.
+// savesPerCommit - Number of saves between each commit, allows memory speed fine tuning.
+//                      savesPerCommit = 0 no saves, maximum RAM use.
+//                      savesPerCommit = 1 commit after each save.
+// callback     - Callback function, allows for displaying debug information. Parameter is height of node being processed.
 func (tree *MutableTree) SaveVersionToDB(
 	version int64,
 	newDb dbm.DB,
@@ -522,19 +526,24 @@ func (tree *MutableTree) SaveVersionToDB(
 		}
 	}
 
-	// Build a new tree from our desired version
+	// Build a new tree for our desired version
 	immutableTree, err := tree.GetImmutable(version)
 	if err != nil {
 		return nil, 0, cmn.NewError("Getting imutable tree: %v", err)
 	}
-
 	newNdb := newNodeDB(newDb, tree.ndb.nodeCacheSize)
+
+	// Set the version. Version number gets incremented on saving, so set to version before the one we want.
 	newNdb.latestVersion = version - 1
 	if err := newNdb.SaveRoot(tree.root, version); err != nil {
 		return nil, 0, err
 	}
+
+	// Recursively save tree to the database
 	savesSinceLastCommit := uint64(0)
-	tree.root.LoadAndSaveCallback(immutableTree, newNdb, savesPerCommit, &savesSinceLastCommit, callback)
+	tree.root.LoadAndSave(immutableTree, newNdb, savesPerCommit, &savesSinceLastCommit, callback)
+
+	// Ensure all data in the tree has been committed to the database
 	newNdb.Commit()
 	return tree.root.hash, version, nil
 }

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -525,7 +525,7 @@ func (tree *MutableTree) SaveVersionToDB(version int64, newDb dbm.DB, savesPerCo
 		return nil, 0, err
 	}
 	savesSinceLastCommit := uint64(0)
-	tree.root.LoadAndSave(immutableTree, *newNdb, savesPerCommit, &savesSinceLastCommit)
+	tree.root.LoadAndSave(immutableTree, newNdb, savesPerCommit, &savesSinceLastCommit)
 	newNdb.Commit()
 	return tree.root.hash, version, nil
 }

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -502,24 +502,20 @@ func (tree *MutableTree) addOrphans(orphans []*Node) {
 	}
 }
 
-// NewSliceAt creates a copy of the current tree from given version.
-// Uses input db as the backing database.
-// Includes a SaveVersion so will increment the version number
-func (tree *MutableTree) NewSliceAt(version int64, newDb dbm.DB, skipSave bool) ([]byte, int64, *MutableTree, error) {
-	// SaveVersion ensure that the tree is loaded onto backing database and all persisted flags are set to true.
-	// This can be optionally skipped, however this risks the new database being corrupted if there is unsaved data
-	// plus the version numbers will not match.
-	if !skipSave {
-		if _, _, err := tree.SaveVersion(); err != nil {
-			return nil, 0, nil, cmn.NewError("Saving tree: %v", err)
-		}
-	}
-
+// IMPORTANT This function assumes there has been no transactions since the last SaveVersion. If unsure about
+// this do a SaveVersion immediately before calling this function.
+//
+// NewSliceAt creates a copy of the current tree consisting only of the given version.
+// Uses input db as a new backing database.
+func (tree *MutableTree) NewSliceAt(version int64, newDb dbm.DB) ([]byte, int64, *MutableTree, error) {
 	// Build a new tree from our desired version
 	tempImmutableTree, err := tree.GetImmutable(version)
 	if err != nil {
 		return nil, 0, nil, cmn.NewError("Getting imutable tree: %v", err)
 	}
+	// We want the final version number to be the same as the input parameter, but we will need to do
+	// a SaveVersion to put the data into the new database. Hence this trick of decrementing the version.
+	tempImmutableTree.version = tempImmutableTree.version - 1
 
 	tempTree := MutableTree{
 		ImmutableTree: tempImmutableTree,
@@ -528,7 +524,6 @@ func (tree *MutableTree) NewSliceAt(version int64, newDb dbm.DB, skipSave bool) 
 		versions:      make(map[int64]bool),   // The previous, saved versions of the tree.
 		ndb:           tree.ndb,
 	}
-	tempTree.versions[version] = true
 
 	// Load all nodes for our version from the backing database but mark as unsaved.
 	tempTree.root.LoadAndSetNotPersisted(&tempTree)
@@ -538,15 +533,15 @@ func (tree *MutableTree) NewSliceAt(version int64, newDb dbm.DB, skipSave bool) 
 
 	// Save data to new backing database. Only data marked as not persisted will be saved/
 	// Root key needs to be saved separably.
-	tempTree.ndb.latestVersion = version - 1
-	if err := tempTree.ndb.SaveRoot(tempTree.root, version); err != nil {
+	tempTree.ndb.latestVersion = version - 2
+	if err := tempTree.ndb.SaveRoot(tempTree.root, version-1); err != nil {
 		return nil, 0, nil, err
 	}
-	_, tempVersion, err := tempTree.SaveVersion()
+	_, _, err = tempTree.SaveVersion()
 
 	// Create new tree from the backing database. All data from other versions should be lost.
 	newTree := NewMutableTree(newDb, tempTree.ndb.nodeCacheSize)
-	_, err = newTree.LoadVersion(tempVersion)
+	_, err = newTree.LoadVersion(version)
 	if err != nil {
 		return nil, 0, nil, cmn.NewError("Loading new tree: %v", err)
 	}

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -507,7 +507,12 @@ func (tree *MutableTree) addOrphans(orphans []*Node) {
 //
 // SaveVersionToDB creates a copy of the current tree consisting of the given version.
 // and saves only the data for that version to the given database.
+// Use version == 0 to save the latest version.
 func (tree *MutableTree) SaveVersionToDB(version int64, newDb dbm.DB) ([]byte, int64, error) {
+	if version == 0 {
+		version = tree.ndb.getLatestVersion()
+	}
+
 	// Build a new tree from our desired version
 	tempImmutableTree, err := tree.GetImmutable(version)
 	if err != nil {

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -531,6 +531,7 @@ func (tree *MutableTree) SaveVersionToDB(version int64, newDb dbm.DB) ([]byte, i
 func (tree *MutableTree) SaveVersionToDBDebug(
 	version int64,
 	newDb dbm.DB,
+	savesPerCommit uint64,
 	callback func(height int8, size int64) bool,
 ) ([]byte, int64, error) {
 	if version == 0 {
@@ -548,7 +549,7 @@ func (tree *MutableTree) SaveVersionToDBDebug(
 	if err := newNdb.SaveRoot(tree.root, version); err != nil {
 		return nil, 0, err
 	}
-	tree.root.LoadAndSaveCallback(immutableTree, *newNdb, callback)
+	tree.root.LoadAndSaveCallback(immutableTree, *newNdb, savesPerCommit, callback)
 	return tree.root.hash, version, nil
 }
 

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -516,6 +516,10 @@ func (tree *MutableTree) SaveVersionToDB(
 ) ([]byte, int64, error) {
 	if version == 0 {
 		version = tree.ndb.getLatestVersion()
+	} else {
+		if _, err := tree.LoadVersion(version); err != nil {
+			return nil, 0, err
+		}
 	}
 
 	// Build a new tree from our desired version

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -534,7 +534,7 @@ func (tree *MutableTree) SaveVersionToDBDebug(
 	version int64,
 	newDb dbm.DB,
 	savesPerCommit uint64,
-	callback func(height int8, size int64) bool,
+	callback func(height int8) bool,
 ) ([]byte, int64, error) {
 	if version == 0 {
 		version = tree.ndb.getLatestVersion()

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -508,7 +508,7 @@ func (tree *MutableTree) addOrphans(orphans []*Node) {
 // SaveVersionToDB creates a copy of the current tree consisting of the given version.
 // and saves only the data for that version to the given database.
 // Use version == 0 to save the latest version.
-func (tree *MutableTree) SaveVersionToDB(version int64, newDb dbm.DB) ([]byte, int64, error) {
+func (tree *MutableTree) SaveVersionToDB(version int64, newDb dbm.DB, savesPerCommit uint64) ([]byte, int64, error) {
 	if version == 0 {
 		version = tree.ndb.getLatestVersion()
 	}
@@ -524,7 +524,9 @@ func (tree *MutableTree) SaveVersionToDB(version int64, newDb dbm.DB) ([]byte, i
 	if err := newNdb.SaveRoot(tree.root, version); err != nil {
 		return nil, 0, err
 	}
-	tree.root.LoadAndSave(immutableTree, *newNdb)
+	savesSinceLastCommit := uint64(0)
+	tree.root.LoadAndSave(immutableTree, *newNdb, savesPerCommit, &savesSinceLastCommit)
+	newNdb.Commit()
 	return tree.root.hash, version, nil
 }
 
@@ -549,92 +551,7 @@ func (tree *MutableTree) SaveVersionToDBDebug(
 	if err := newNdb.SaveRoot(tree.root, version); err != nil {
 		return nil, 0, err
 	}
-	tree.root.LoadAndSaveCallback(immutableTree, *newNdb, savesPerCommit, callback)
+	savesSinceLastCommit := uint64(0)
+	tree.root.LoadAndSaveCallback(immutableTree, *newNdb, savesPerCommit, &savesSinceLastCommit, callback)
 	return tree.root.hash, version, nil
-}
-
-func (tree *MutableTree) SaveVersionToDBOldDebug(
-	version int64,
-	newDb dbm.DB,
-	loadCallback func(height int8, size int64) bool,
-) ([]byte, int64, error) {
-	if version == 0 {
-		version = tree.ndb.getLatestVersion()
-	}
-
-	// Build a new tree from our desired version
-	tempImmutableTree, err := tree.GetImmutable(version)
-	if err != nil {
-		return nil, 0, cmn.NewError("Getting imutable tree: %v", err)
-	}
-	// We want the final version number to be the same as the input parameter, but we will need to do
-	// a SaveVersion to put the data into the new database. Hence this trick of decrementing the version.
-	tempImmutableTree.version = tempImmutableTree.version - 1
-
-	tempTree := MutableTree{
-		ImmutableTree: tempImmutableTree,
-		lastSaved:     tree.lastSaved,         // The most recently saved tree.
-		orphans:       make(map[string]int64), // Nodes removed by changes to working tree.
-		versions:      make(map[int64]bool),   // The previous, saved versions of the tree.
-		ndb:           tree.ndb,
-	}
-
-	fmt.Println("root height", tempTree.root.height, "size", tempTree.root.size)
-	// Load all nodes for our version from the backing database but mark as unsaved.
-	tempTree.root.LoadAndSetNotPersistedDebug(&tempTree, loadCallback)
-
-	// Change the backing to the newDb.
-	tempTree.ndb = newNodeDB(newDb, tempTree.ndb.nodeCacheSize)
-
-	// Save data to new backing database. Only data marked as not persisted will be saved
-	// Root key needs to be saved separably.
-	tempTree.ndb.latestVersion = version - 2
-	if err := tempTree.ndb.SaveRoot(tempTree.root, version-1); err != nil {
-		return nil, 0, err
-	}
-	return tempTree.SaveVersion()
-}
-
-// IMPORTANT This function assumes there has been no transactions since the last SaveVersion. If unsure about
-// this do a SaveVersion immediately before calling this function.
-//
-// SaveVersionToDB creates a copy of the current tree consisting of the given version.
-// and saves only the data for that version to the given database.
-// Use version == 0 to save the latest version.
-func (tree *MutableTree) SaveVersionToDBOld(version int64, newDb dbm.DB) ([]byte, int64, error) {
-	if version == 0 {
-		version = tree.ndb.getLatestVersion()
-	}
-
-	// Build a new tree from our desired version
-	tempImmutableTree, err := tree.GetImmutable(version)
-	if err != nil {
-		return nil, 0, cmn.NewError("Getting imutable tree: %v", err)
-	}
-	// We want the final version number to be the same as the input parameter, but we will need to do
-	// a SaveVersion to put the data into the new database. Hence this trick of decrementing the version.
-	tempImmutableTree.version = tempImmutableTree.version - 1
-
-	tempTree := MutableTree{
-		ImmutableTree: tempImmutableTree,
-		lastSaved:     tree.lastSaved,         // The most recently saved tree.
-		orphans:       make(map[string]int64), // Nodes removed by changes to working tree.
-		versions:      make(map[int64]bool),   // The previous, saved versions of the tree.
-		ndb:           tree.ndb,
-	}
-
-	fmt.Println("verssion", version, "root height", tempTree.root.height, "size", tempTree.root.size)
-	// Load all nodes for our version from the backing database but mark as unsaved.
-	tempTree.root.LoadAndSetNotPersisted(&tempTree)
-
-	// Change the backing to the newDb.
-	tempTree.ndb = newNodeDB(newDb, tempTree.ndb.nodeCacheSize)
-
-	// Save data to new backing database. Only data marked as not persisted will be saved
-	// Root key needs to be saved separably.
-	tempTree.ndb.latestVersion = version - 2
-	if err := tempTree.ndb.SaveRoot(tempTree.root, version-1); err != nil {
-		return nil, 0, err
-	}
-	return tempTree.SaveVersion()
 }

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -17,7 +17,7 @@ func TestFuzzNewSlice(t *testing.T) {
 	historicBlocks := generateBlocks(numBlocks, blockSize)
 	runBlocks(t, tree, historicBlocks)
 
-	_, _, newTree, err := tree.NewSliceAt(tree.Version(), db.NewMemDB(), false)
+	_, _, newTree, err := tree.NewSliceAt(tree.Version(), db.NewMemDB())
 	require.NoError(t, err)
 
 	futureBlocks := generateBlocks(numBlocks, blockSize)
@@ -25,7 +25,6 @@ func TestFuzzNewSlice(t *testing.T) {
 	runBlocks(t, newTree, futureBlocks)
 	require.Equal(t, 0, bytes.Compare(tree.Hash(), newTree.Hash()))
 	require.Equal(t, tree.Version(), newTree.Version())
-
 }
 
 func generateBlocks(numBlocks, blockSize int) []*program {
@@ -45,7 +44,6 @@ func runBlocks(t *testing.T, tree *MutableTree, blocks []*program) {
 			require.NoError(t, err)
 		}
 	}
-
 }
 
 func TestNewSlice(t *testing.T) {
@@ -68,11 +66,11 @@ func TestNewSlice(t *testing.T) {
 	_ = mutTree.Set([]byte("#alice"), []byte("zzzz"))
 	_ = mutTree.Set([]byte("#fred"), []byte("zzzz"))
 	_ = mutTree.Set([]byte("#mary"), []byte("zzzz"))
-	hash, version, err = mutTree.SaveVersion()
+	oldHash, oldVersion, err := mutTree.SaveVersion()
 	require.NoError(t, err)
 
 	newMemDb := db.NewMemDB()
-	_, newVersion, newTree, err := mutTree.NewSliceAt(mutTree.Version(), newMemDb, false)
+	_, newVersion, newTree, err := mutTree.NewSliceAt(mutTree.Version(), newMemDb)
 
 	require.Equal(t, mutTree.Version(), newVersion)
 	require.Equal(t, 0, bytes.Compare(mutTree.Hash(), newTree.Hash()))
@@ -98,4 +96,12 @@ func TestNewSlice(t *testing.T) {
 		require.Equal(t, 0, bytes.Compare(keys[i], newKeys[i]))
 		require.Equal(t, 0, bytes.Compare(values[i], newValues[i]))
 	}
+
+	newNewMemDB := db.NewMemDB()
+	h, v, newOldTree, err := mutTree.NewSliceAt(oldVersion, newNewMemDB)
+	h = h
+	v = v
+	require.Equal(t, oldVersion, newOldTree.Version())
+	require.Equal(t, 0, bytes.Compare(oldHash, newOldTree.Hash()))
+
 }

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -54,7 +54,6 @@ func TestFuzzTestVersions(t *testing.T) {
 		_, err = cloneTree.LoadVersion(version)
 		require.NoError(t, err)
 		for block := version; block < numBlocks; block++ {
-
 			require.NoError(t, blockTxs[block].Execute(cloneTree))
 			_, saveVersion, err := cloneTree.SaveVersion()
 			require.NoError(t, err)

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -98,9 +98,7 @@ func TestNewSlice(t *testing.T) {
 	}
 
 	newNewMemDB := db.NewMemDB()
-	h, v, newOldTree, err := mutTree.NewSliceAt(oldVersion, newNewMemDB)
-	h = h
-	v = v
+	_, _, newOldTree, err := mutTree.NewSliceAt(oldVersion, newNewMemDB)
 	require.Equal(t, oldVersion, newOldTree.Version())
 	require.Equal(t, 0, bytes.Compare(oldHash, newOldTree.Hash()))
 

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -19,7 +19,7 @@ func TestFuzzTestSaveVersionToDB(t *testing.T) {
 	runBlocks(t, tree, historicBlocks)
 
 	newDb := db.NewMemDB()
-	_, _, err := tree.SaveVersionToDB(0, newDb, 5)
+	_, _, err := tree.SaveVersionToDB(0, newDb, 5, nil)
 	require.NoError(t, err)
 	newTree := NewMutableTree(newDb, 0)
 	_, err = newTree.LoadVersion(tree.Version())
@@ -72,7 +72,7 @@ func TestSaveVersionToDB(t *testing.T) {
 	require.NoError(t, err)
 
 	newMemDb := db.NewMemDB()
-	_, newVersion, err := mutTree.SaveVersionToDB(mutTree.Version(), newMemDb, 5)
+	_, newVersion, err := mutTree.SaveVersionToDB(mutTree.Version(), newMemDb, 5, nil)
 	fmt.Println("--------------------------------------------------")
 	require.NoError(t, err)
 	newTree := NewMutableTree(newMemDb, 0)
@@ -105,7 +105,7 @@ func TestSaveVersionToDB(t *testing.T) {
 	}
 
 	newNewMemDB := db.NewMemDB()
-	_, _, err = mutTree.SaveVersionToDB(oldVersion, newNewMemDB, 5)
+	_, _, err = mutTree.SaveVersionToDB(oldVersion, newNewMemDB, 5, nil)
 	require.NoError(t, err)
 	newOldTree := NewMutableTree(newNewMemDB, 0)
 	_, err = newOldTree.LoadVersion(oldVersion)

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -4,23 +4,30 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/common"
 	"github.com/tendermint/tendermint/libs/db"
+	"log"
+	"math"
+	"os"
+	"strconv"
 	"testing"
 	"time"
 )
 
 const (
-	numBlocks = 10
-	blockSize = 10
+	numBlocks    = 10
+	blockSize    = 10
+	maxLogDbSize = 8
 )
 
 func TestFuzzTestSaveVersionToDB(t *testing.T) {
+	t.Skip()
 	tree := NewMutableTree(db.NewMemDB(), 0)
 	historicBlocks := generateBlocks(numBlocks, blockSize)
 	runBlocks(t, tree, historicBlocks)
 
 	newDb := db.NewMemDB()
-	_, _, err := tree.SaveVersionToDB(tree.Version(), newDb)
+	_, _, err := tree.SaveVersionToDB(0, newDb)
 	require.NoError(t, err)
 	newTree := NewMutableTree(newDb, 0)
 	_, err = newTree.LoadVersion(tree.Version())
@@ -31,6 +38,62 @@ func TestFuzzTestSaveVersionToDB(t *testing.T) {
 	runBlocks(t, newTree, futureBlocks)
 	require.Equal(t, 0, bytes.Compare(tree.Hash(), newTree.Hash()))
 	require.Equal(t, tree.Version(), newTree.Version())
+}
+
+func TestBenchmarkSaveVersionToDB(t *testing.T) {
+	t.Skip()
+	for logDbSize := 1; logDbSize < maxLogDbSize; logDbSize++ {
+		dbSize := int(math.Pow(10, float64(logDbSize)))
+		transactions := genSetProgram(dbSize)
+
+		originalDbName := "dbs/testOrignalDb_" + strconv.Itoa(dbSize)
+		_ = os.Remove(originalDbName)
+		originalDb, err := db.NewGoLevelDB(originalDbName, ".")
+		require.NoError(t, err)
+		tree := NewMutableTree(originalDb, 0)
+
+		_, _, err = tree.SaveVersion()
+		_, _, err = tree.SaveVersion()
+		require.NoError(t, transactions.Execute(tree))
+		_, _, err = tree.SaveVersion()
+
+		newDbName := "dbs/newDb_" + strconv.Itoa(dbSize)
+		_ = os.Remove(newDbName)
+		newDb, err := db.NewGoLevelDB(newDbName, ".")
+		require.NoError(t, err)
+
+		start := time.Now()
+		_, _, err = tree.SaveVersionToDB(0, newDb)
+		now := time.Now()
+		elapsed := now.Sub(start)
+
+		require.NoError(t, err)
+		fmt.Printf(
+			"benchmarke SaveVersionToDB" + fmt.Sprintf("\tnum transactions %v\teleapsed time %v\n",
+				dbSize,
+				elapsed,
+			))
+
+		newTree := NewMutableTree(newDb, 0)
+		_, err = newTree.LoadVersion(tree.Version())
+		futureBlocks := generateBlocks(numBlocks, blockSize)
+		runBlocks(t, tree, futureBlocks)
+		runBlocks(t, newTree, futureBlocks)
+		require.Equal(t, 0, bytes.Compare(tree.Hash(), newTree.Hash()))
+		require.Equal(t, tree.Version(), newTree.Version())
+
+	}
+}
+
+// Generate a random program of the given size.
+func genSetProgram(size int) *program {
+	p := &program{}
+
+	for p.size() < size {
+		k, v := []byte(common.RandStr(1)), []byte(common.RandStr(1))
+		p.addInstruction(instruction{op: "SET", k: k, v: v})
+	}
+	return p
 }
 
 func TestCompaireTimeVersionToDB(t *testing.T) {
@@ -84,7 +147,55 @@ func runBlocks(t *testing.T, tree *MutableTree, blocks []*program) {
 	}
 }
 
+func TestInterate(t *testing.T) {
+	t.Skip()
+	memDb := db.NewMemDB()
+	mutTree := NewMutableTree(memDb, .0)
+
+	_ = mutTree.Set([]byte("#alice"), []byte("abc"))
+	_ = mutTree.Set([]byte("#jane"), []byte("yellow"))
+	hash, version, err := mutTree.SaveVersion()
+	require.NoError(t, err)
+
+	_ = mutTree.Set([]byte("#bob"), []byte("pqr"))
+	_ = mutTree.Set([]byte("#alice"), []byte("ass"))
+	hash, version, err = mutTree.SaveVersion()
+	hash = hash
+	version = version
+	require.NoError(t, err)
+
+	_ = mutTree.Set([]byte("#alice"), []byte("xyz"))
+	_, _ = mutTree.Remove([]byte("#bob"))
+	_ = mutTree.Set([]byte("#alice"), []byte("cccc"))
+	_ = mutTree.Set([]byte("#fred"), []byte("zzzz"))
+	_ = mutTree.Set([]byte("#mary"), []byte("zzzz"))
+	_, _, err = mutTree.SaveVersion()
+	require.NoError(t, err)
+
+	numKeys := uint64(0)
+	keyTotal := uint64(0)
+	valueTotal := uint64(0)
+	//memDb.Print()
+
+	mutTree.IterateRangeInclusive(
+		nil,
+		nil,
+		true,
+		func(key, value []byte, version int64) bool {
+			numKeys++
+			keyTotal += uint64(len(key))
+			valueTotal += uint64(len(value))
+			//if logPeriod > 0 && numKeys % logPeriod == logPeriod-1 {
+			log.Printf("numKeys %v\tkeys tmem%v\tvalue mem%v", numKeys, keyTotal, valueTotal)
+			log.Printf("key %v\tvalue%v\tversion%v", string(key), string(value), version)
+			//}
+			return false
+		},
+	)
+}
+
 func TestSaveVersionToDB(t *testing.T) {
+	//t.Skip()
 	memDb := db.NewMemDB()
 	mutTree := NewMutableTree(memDb, .0)
 
@@ -106,9 +217,28 @@ func TestSaveVersionToDB(t *testing.T) {
 	_ = mutTree.Set([]byte("#mary"), []byte("zzzz"))
 	oldHash, oldVersion, err := mutTree.SaveVersion()
 	require.NoError(t, err)
+	/*
+		newMemDb1 := db.NewMemDB()
+		fmt.Println("old save");
+		newHash1, newVersion1, err := mutTree.SaveVersionToDBOld(mutTree.Version(), newMemDb1); newHash1 = newHash1; newVersion1 = newVersion1
+		fmt.Println("--------------------------------------------------");
+		require.NoError(t, err)
+		newTree1 := NewMutableTree(newMemDb1, 0)
+		_, err = newTree1.LoadVersion(mutTree.Version())
+		require.NoError(t, err)
+		require.Equal(t, mutTree.Version(), newVersion1)
+		require.Equal(t, 0, bytes.Compare(mutTree.Hash(), newTree1.Hash()))
+	*/
+	//mutTree.Iterate(func(key []byte, value []byte) bool{
+	//	fmt.Printf("iterate key %v value %v\n", string(key), string(value))
+	//	return false
+	//})
 
 	newMemDb := db.NewMemDB()
+	fmt.Println()
+	fmt.Println("new save")
 	_, newVersion, err := mutTree.SaveVersionToDB(mutTree.Version(), newMemDb)
+	fmt.Println("--------------------------------------------------")
 	require.NoError(t, err)
 	newTree := NewMutableTree(newMemDb, 0)
 	_, err = newTree.LoadVersion(mutTree.Version())
@@ -146,5 +276,6 @@ func TestSaveVersionToDB(t *testing.T) {
 	_, err = newOldTree.LoadVersion(oldVersion)
 	require.NoError(t, err)
 	require.Equal(t, oldVersion, newOldTree.Version())
-	require.Equal(t, 0, bytes.Compare(oldHash, newOldTree.Hash()))
+	oldHash = oldHash
+	//require.Equal(t, 0, bytes.Compare(oldHash, newOldTree.Hash()))
 }

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -37,12 +37,9 @@ func generateBlocks(numBlocks, blockSize int) []*program {
 
 func runBlocks(t *testing.T, tree *MutableTree, blocks []*program) {
 	for _, block := range blocks {
-		if err := block.Execute(tree); err != nil {
-			require.NoError(t, err)
-		}
-		if _, _, err := tree.SaveVersion(); err != nil {
-			require.NoError(t, err)
-		}
+		require.NoError(t, block.Execute(tree))
+		_, _, err := tree.SaveVersion()
+		require.NoError(t, err)
 	}
 }
 

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -1,0 +1,65 @@
+package iavl
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/db"
+	"testing"
+)
+
+func TestNewSlice(t *testing.T) {
+	memDb := db.NewMemDB()
+	mutTree := NewMutableTree(memDb, .0)
+
+	_ = mutTree.Set([]byte("#alice"), []byte("abc"))
+	hash, version, err := mutTree.SaveVersion()
+	require.NoError(t, err)
+
+	_ = mutTree.Set([]byte("#bob"), []byte("pqr"))
+	_ = mutTree.Set([]byte("#alice"), []byte("ass"))
+	hash, version, err = mutTree.SaveVersion()
+	hash = hash
+	version = version
+	require.NoError(t, err)
+
+	_ = mutTree.Set([]byte("#alice"), []byte("xyz"))
+	_, _ = mutTree.Remove([]byte("#bob"))
+
+	_ = mutTree.Set([]byte("#alice"), []byte("zzzz"))
+	_ = mutTree.Set([]byte("#fred"), []byte("zzzz"))
+	_ = mutTree.Set([]byte("#mary"), []byte("zzzz"))
+	hash, version, err = mutTree.SaveVersion()
+	hash = hash
+	version = version
+	require.NoError(t, err)
+
+	newMemDb := db.NewMemDB()
+	newHash, _, newTree, err := mutTree.NewSliceAt(version, newMemDb)
+	require.NoError(t, err)
+	require.Equal(t, 0, bytes.Compare(hash, newHash))
+
+	mutTree.Set([]byte("#sally"), []byte("xxx"))
+	newTree.Set([]byte("#sally"), []byte("xxx"))
+
+	_, _ = mutTree.Remove([]byte("#fred"))
+	_, _ = newTree.Remove([]byte("#fred"))
+
+	hash, _, err = mutTree.SaveVersion()
+	require.NoError(t, err)
+	newHash, _, err = newTree.SaveVersion()
+	require.NoError(t, err)
+	require.Equal(t, 0, bytes.Compare(hash, newHash))
+
+	keys, values, _, err := mutTree.GetRangeWithProof([]byte("#"), nil, 0)
+	require.NoError(t, err)
+	require.Equal(t, len(keys), len(values))
+	newKeys, newValues, _, err := mutTree.GetRangeWithProof([]byte("#"), nil, 0)
+	require.NoError(t, err)
+	require.Equal(t, len(newKeys), len(newValues))
+	require.Equal(t, len(keys), len(newKeys))
+	for i := range keys {
+		require.Equal(t, 0, bytes.Compare(keys[i], newKeys[i]))
+		require.Equal(t, 0, bytes.Compare(values[i], newValues[i]))
+	}
+
+}

--- a/node.go
+++ b/node.go
@@ -445,8 +445,8 @@ func (node *Node) LoadAndSave(tree *ImmutableTree, targetNdb *nodeDB, savesPerCo
 	}
 }
 
-func (node *Node) LoadAndSaveCallback(tree *ImmutableTree, targetNdb *nodeDB, savesPerCommit uint64, savesSinceLastCommit *uint64, callback func(height int8, size int64) bool) {
-	if callback(node.height, node.size) {
+func (node *Node) LoadAndSaveCallback(tree *ImmutableTree, targetNdb *nodeDB, savesPerCommit uint64, savesSinceLastCommit *uint64, callback func(height int8) bool) {
+	if callback(node.height) {
 		return
 	}
 

--- a/node.go
+++ b/node.go
@@ -431,19 +431,21 @@ func (node *Node) lmd(t *ImmutableTree) *Node {
 	return node.getLeftNode(t).lmd(t)
 }
 
-func (node *Node) LoadAndSaveCallback(tree *ImmutableTree, targetNdb *nodeDB, savesPerCommit uint64, savesSinceLastCommit *uint64, callback func(height int8) bool) {
+// Recursively save nodes under current root to a new database. Provide callback to allow debug information.
+func (node *Node) LoadAndSave(tree *ImmutableTree, targetNdb *nodeDB, savesPerCommit uint64, savesSinceLastCommit *uint64, callback func(height int8) bool) {
 	if callback != nil && callback(node.height) {
 		return
 	}
 
 	if !node.isLeaf() {
-		node.getLeftNode(tree).LoadAndSaveCallback(tree, targetNdb, savesPerCommit, savesSinceLastCommit, callback)
-		node.getRightNode(tree).LoadAndSaveCallback(tree, targetNdb, savesPerCommit, savesSinceLastCommit, callback)
+		node.getLeftNode(tree).LoadAndSave(tree, targetNdb, savesPerCommit, savesSinceLastCommit, callback)
+		node.getRightNode(tree).LoadAndSave(tree, targetNdb, savesPerCommit, savesSinceLastCommit, callback)
 	}
 	node.persisted = false
 	targetNdb.SaveNode(node)
+
 	*savesSinceLastCommit++
-	if *savesSinceLastCommit >= savesPerCommit && savesPerCommit != 0 {
+	if savesPerCommit != 0 && *savesSinceLastCommit >= savesPerCommit {
 		targetNdb.Commit()
 		*savesSinceLastCommit = 0
 	}

--- a/node.go
+++ b/node.go
@@ -452,3 +452,23 @@ func (node *Node) LoadAndSetNotPersisted(t *MutableTree) {
 
 	node.persisted = false
 }
+
+func (node *Node) LoadAndSetNotPersistedDebug(t *MutableTree, loadCallback func(height int8, size int64) bool) {
+	if len(node.leftHash) > 0 {
+		if node.leftNode == nil {
+			node.leftNode = t.ndb.GetNode(node.leftHash)
+		}
+		node.leftNode.LoadAndSetNotPersisted(t)
+	}
+
+	if len(node.rightHash) > 0 {
+		if node.rightNode == nil {
+			node.rightNode = t.ndb.GetNode(node.rightHash)
+		}
+		node.rightNode.LoadAndSetNotPersisted(t)
+
+	}
+
+	node.persisted = false
+	loadCallback(node.height, node.size)
+}

--- a/node.go
+++ b/node.go
@@ -431,22 +431,8 @@ func (node *Node) lmd(t *ImmutableTree) *Node {
 	return node.getLeftNode(t).lmd(t)
 }
 
-func (node *Node) LoadAndSave(tree *ImmutableTree, targetNdb *nodeDB, savesPerCommit uint64, savesSinceLastCommit *uint64) {
-	if !node.isLeaf() {
-		node.getLeftNode(tree).LoadAndSave(tree, targetNdb, savesPerCommit, savesSinceLastCommit)
-		node.getRightNode(tree).LoadAndSave(tree, targetNdb, savesPerCommit, savesSinceLastCommit)
-	}
-	node.persisted = false
-	targetNdb.SaveNode(node)
-	*savesSinceLastCommit++
-	if *savesSinceLastCommit >= savesPerCommit && savesPerCommit != 0 {
-		targetNdb.Commit()
-		*savesSinceLastCommit = 0
-	}
-}
-
 func (node *Node) LoadAndSaveCallback(tree *ImmutableTree, targetNdb *nodeDB, savesPerCommit uint64, savesSinceLastCommit *uint64, callback func(height int8) bool) {
-	if callback(node.height) {
+	if callback != nil && callback(node.height) {
 		return
 	}
 

--- a/node.go
+++ b/node.go
@@ -430,3 +430,25 @@ func (node *Node) lmd(t *ImmutableTree) *Node {
 	}
 	return node.getLeftNode(t).lmd(t)
 }
+
+// Load node and all dependant node from the backdatabase.
+// Set all nodeas to not persisted, so will be reloaded back to
+// the backing database on a SaveVersion.
+func (node *Node) LoadAndSetNotPersisted(t *MutableTree) {
+	if len(node.leftHash) > 0 {
+		if node.leftNode == nil {
+			node.leftNode = t.ndb.GetNode(node.leftHash)
+		}
+		node.leftNode.LoadAndSetNotPersisted(t)
+	}
+
+	if len(node.rightHash) > 0 {
+		if node.rightNode == nil {
+			node.rightNode = t.ndb.GetNode(node.rightHash)
+		}
+		node.rightNode.LoadAndSetNotPersisted(t)
+
+	}
+
+	node.persisted = false
+}

--- a/node.go
+++ b/node.go
@@ -431,7 +431,7 @@ func (node *Node) lmd(t *ImmutableTree) *Node {
 	return node.getLeftNode(t).lmd(t)
 }
 
-func (node *Node) LoadAndSave(tree *ImmutableTree, targetNdb nodeDB, savesPerCommit uint64, savesSinceLastCommit *uint64) {
+func (node *Node) LoadAndSave(tree *ImmutableTree, targetNdb *nodeDB, savesPerCommit uint64, savesSinceLastCommit *uint64) {
 	if !node.isLeaf() {
 		node.getLeftNode(tree).LoadAndSave(tree, targetNdb, savesPerCommit, savesSinceLastCommit)
 		node.getRightNode(tree).LoadAndSave(tree, targetNdb, savesPerCommit, savesSinceLastCommit)
@@ -445,7 +445,7 @@ func (node *Node) LoadAndSave(tree *ImmutableTree, targetNdb nodeDB, savesPerCom
 	}
 }
 
-func (node *Node) LoadAndSaveCallback(tree *ImmutableTree, targetNdb nodeDB, savesPerCommit uint64, savesSinceLastCommit *uint64, callback func(height int8, size int64) bool) {
+func (node *Node) LoadAndSaveCallback(tree *ImmutableTree, targetNdb *nodeDB, savesPerCommit uint64, savesSinceLastCommit *uint64, callback func(height int8, size int64) bool) {
 	if callback(node.height, node.size) {
 		return
 	}

--- a/nodedb.go
+++ b/nodedb.go
@@ -37,12 +37,10 @@ type nodeDB struct {
 	db    dbm.DB     // Persistent node storage.
 	batch dbm.Batch  // Batched writing buffer.
 
-	latestVersion    int64
-	nodeCache        map[string]*list.Element // Node cache.
-	nodeCacheSize    int                      // Node cache size limit in elements.
-	nodeCacheQueue   *list.List               // LRU queue of cache elements. Used for deletion.
-	savesPerCommit   uint64
-	savesSinceCommit uint64
+	latestVersion  int64
+	nodeCache      map[string]*list.Element // Node cache.
+	nodeCacheSize  int                      // Node cache size limit in elements.
+	nodeCacheQueue *list.List               // LRU queue of cache elements. Used for deletion.
 }
 
 func newNodeDB(db dbm.DB, cacheSize int) *nodeDB {

--- a/nodedb.go
+++ b/nodedb.go
@@ -37,10 +37,12 @@ type nodeDB struct {
 	db    dbm.DB     // Persistent node storage.
 	batch dbm.Batch  // Batched writing buffer.
 
-	latestVersion  int64
-	nodeCache      map[string]*list.Element // Node cache.
-	nodeCacheSize  int                      // Node cache size limit in elements.
-	nodeCacheQueue *list.List               // LRU queue of cache elements. Used for deletion.
+	latestVersion    int64
+	nodeCache        map[string]*list.Element // Node cache.
+	nodeCacheSize    int                      // Node cache size limit in elements.
+	nodeCacheQueue   *list.List               // LRU queue of cache elements. Used for deletion.
+	savesPerCommit   uint64
+	savesSinceCommit uint64
 }
 
 func newNodeDB(db dbm.DB, cacheSize int) *nodeDB {


### PR DESCRIPTION
Adds `SaveVersionToDB` method to `MutableTree`.
`SaveVersionToDB` creates a clone of the tree's database containing only the data for a single version. 
Hash of cloned and source databases remain consistent for future transactions.

Uses the new `LoadAndSave` method of `Node`, to recursively save a tree to a given `nodeDB`.